### PR TITLE
Calculate camera vertical FOV within shader

### DIFF
--- a/addons/starlight/Star.gdshader
+++ b/addons/starlight/Star.gdshader
@@ -10,9 +10,6 @@ uniform float meters_per_lightyear = 100.0;
 uniform float color_gamma : hint_range(0.0, 10.0) = 1.0;
 uniform bool clamp_output = false;
 
-// This should really be a godot shader builtin.
-uniform float camera_vertical_fov = 70;
-
 // PSF cropping related uniforms:
 uniform float min_size_ratio : hint_range(0, 1.0) = 1.0;
 uniform float max_luminosity;
@@ -57,6 +54,7 @@ void vertex() {
 	// Do actual perspective projection.
 	vec4 projected = PROJECTION_MATRIX * vec4(modelview_pos, 1.0);
 	// Figure out the scaling to use in clip space so that we can measure in degrees instead of device pixels.
+	float camera_vertical_fov = degrees(atan(-1.0 / PROJECTION_MATRIX[1][1]) * 2.0);
 	vec2 one_degree = vec2(1.0, VIEWPORT_SIZE.x / VIEWPORT_SIZE.y) / camera_vertical_fov;
 	// Offset the projected position to form the quad.
 	POSITION = projected + vec4(VERTEX.xy * projected.w * size * one_degree, 0.0, 0.0);

--- a/addons/starlight/StarManager.gd
+++ b/addons/starlight/StarManager.gd
@@ -107,11 +107,6 @@ static func blackbody_to_rgb(kelvin):
 
 var material: ShaderMaterial
 var mesh: MultiMesh
-# Hide these parameters because they're set by StarManager:
-var internal_shader_params = {
-	'camera_vertical_fov': true
-}
-
 
 # This forwards the shader parameters, which would otherwise be inaccessible because the Material
 # is generated at runtime.
@@ -119,8 +114,6 @@ func _get_property_list():
 	var props = []
 	var shader_params := RenderingServer.get_shader_parameter_list(shader.get_rid())
 	for p in shader_params:
-		if internal_shader_params.has(p.name):
-			continue
 		var cp = {}
 		for k in p:
 			cp[k] = p[k]
@@ -185,12 +178,4 @@ func set_star_list(star_list: Array[Star]):
 
 
 func _process(_delta):
-	var camera = get_viewport().get_camera_3d()
-	var fov = 70
-	# The camera can be null if the scene doesn't have one set.
-	# This value will also not match the editor camera.
-	if camera:
-		fov = camera.fov
-
-	material.shader = shader
-	material.set_shader_parameter('camera_vertical_fov', fov)
+	pass


### PR DESCRIPTION
Thanks to Glitshy's "How to Get Vertical Camera FOV" shader [snippet](https://godotshaders.com/shader/how-to-get-vertical-camera-fov/).

Removed camera FOV code from `StarManager.gd`